### PR TITLE
autofill any fields that appear in the querystring

### DIFF
--- a/index.html
+++ b/index.html
@@ -768,27 +768,28 @@
 					micr.call($('.number'));
 				};
 				return;
-			} else {
-				/* try and parse the querystring for values, convert to regular object for dot notation */
-				var params = Object.fromEntries((new URLSearchParams(location.search)).entries());
-
-				// param takes precedence over today's date but fill it in either way
-				$('.date .font').text(params.date || new Date().toLocaleDateString("en-US").replace(/\//g, '-')).attr("blank", false);
-
-				params.payee && $('.payee .font').text(params.payee).attr("blank", false);
-				params.amount && $('.amount .font').text(params.amount).attr("blank", false);
-				params.amounts && $('.amounts .font').text(params.amounts).attr("blank", false);
-				params.bank && $('.bank').text(params.bank).attr("blank", false);
-				params.memo && $('.memo .font').text(params.memo).attr("blank", false);
-
-				/* expected from the recipient */
-				// $('.address')
-				// $('.fraction')
-				// $('.signature .font')
-				// $('.inroute input')
-				// $('.inaccount input')
-				// $('.number')
 			}
+
+			/* try and parse the querystring for values, convert to regular object for dot notation */
+			var params = Object.fromEntries((new URLSearchParams(location.search)).entries());
+
+			// param takes precedence over today's date but fill it in either way
+			$('.date .font').text(params.date || new Date().toLocaleDateString("en-US").replace(/\//g, '-')).attr("blank", false);
+
+			params.payee && $('.payee .font').text(params.payee).attr("blank", false);
+			params.amount && $('.amount .font').text(params.amount).attr("blank", false);
+			params.amounts && $('.amounts .font').text(params.amounts).attr("blank", false);
+			params.bank && $('.bank').text(params.bank).attr("blank", false);
+			params.memo && $('.memo .font').text(params.memo).attr("blank", false);
+
+			/* expected from the recipient */
+			// $('.address')
+			// $('.fraction')
+			// $('.signature .font')
+			// $('.inroute input')
+			// $('.inaccount input')
+			// $('.number')
+		
 
 			$('.inroute input').on('keyup', micr);
 			$('.inaccount input').on('keyup', micr);

--- a/index.html
+++ b/index.html
@@ -773,7 +773,7 @@
 				var params = Object.fromEntries((new URLSearchParams(location.search)).entries());
 
 				// param takes precedence over today's date but fill it in either way
-				$('.date .font').text(params.date || new Date().toLocaleDateString("en-US")).attr("blank", false);
+				$('.date .font').text(params.date || new Date().toLocaleDateString("en-US").replace(/\//g, '-')).attr("blank", false);
 
 				params.payee && $('.payee .font').text(params.payee).attr("blank", false);
 				params.amount && $('.amount .font').text(params.amount).attr("blank", false);

--- a/index.html
+++ b/index.html
@@ -770,18 +770,20 @@
 				return;
 			} else {
 				/* try and parse the querystring for values, convert to regular object for dot notation */
-				var params = Object.fromEntries((new URLSearchParams(location.search)).entries())
+				var params = Object.fromEntries((new URLSearchParams(location.search)).entries());
 
-				params.address && $('.address').text(params.address).attr("blank", false)
-				params.date && $('.date .font').text(params.date).attr("blank", false);
+				// param takes precedence over today's date but fill it in either way
+				$('.date .font').text(params.date || new Date().toLocaleDateString("en-US")).attr("blank", false);
+
 				params.payee && $('.payee .font').text(params.payee).attr("blank", false);
 				params.amount && $('.amount .font').text(params.amount).attr("blank", false);
 				params.amounts && $('.amounts .font').text(params.amounts).attr("blank", false);
-				params.bank && $('.bank').text(params.bank).attr("blank", false)
-				params.memo && $('.memo .font').text(params.memo).attr("blank", false)
-				params.fraction && $('.fraction').text(params.fraction).attr("blank", false)
+				params.bank && $('.bank').text(params.bank).attr("blank", false);
+				params.memo && $('.memo .font').text(params.memo).attr("blank", false);
 
 				/* expected from the recipient */
+				// $('.address')
+				// $('.fraction')
 				// $('.signature .font')
 				// $('.inroute input')
 				// $('.inaccount input')

--- a/index.html
+++ b/index.html
@@ -768,6 +768,24 @@
 					micr.call($('.number'));
 				};
 				return;
+			} else {
+				/* try and parse the querystring for values, convert to regular object for dot notation */
+				var params = Object.fromEntries((new URLSearchParams(location.search)).entries())
+
+				params.address && $('.address').text(params.address).attr("blank", false)
+				params.date && $('.date .font').text(params.date).attr("blank", false);
+				params.payee && $('.payee .font').text(params.payee).attr("blank", false);
+				params.amount && $('.amount .font').text(params.amount).attr("blank", false);
+				params.amounts && $('.amounts .font').text(params.amounts).attr("blank", false);
+				params.bank && $('.bank').text(params.bank).attr("blank", false)
+				params.memo && $('.memo .font').text(params.memo).attr("blank", false)
+				params.fraction && $('.fraction').text(params.fraction).attr("blank", false)
+
+				/* expected from the recipient */
+				// $('.signature .font')
+				// $('.inroute input')
+				// $('.inaccount input')
+				// $('.number')
 			}
 
 			$('.inroute input').on('keyup', micr);


### PR DESCRIPTION
This adds an else branch so that if no key/code was detected for loading a saved check, the query string will be parsed for possible details instead.

In order to hide the placeholder text it was also necessary to call attr("blank", false) on each field that is programmatically filled. 