### PR TITLE
Stylefix safari

### DIFF
--- a/index.html
+++ b/index.html
@@ -261,8 +261,8 @@
 			padding-top: 1em;
 		}
 		.moneys .details {
-			font-size: 0.5em;
-			width: 7em;
+			font-size: 8px;
+			max-width: 65px;
 			padding-top: 0em;
 		}
 		.moneys .lock {

--- a/index.html
+++ b/index.html
@@ -244,26 +244,28 @@
 			letter-spacing: 0.1em;
 			width: 60%;
 		}
-		.amounts {
-			float: left;
-			width: 80%;
-			font-size: 1.4em;
-			margin-left: 0.7em;
-			padding-left: 2%;
-			border-bottom: solid black 1px;
+		.moneys {
+			display: flex;
 		}
-		.amounts .font, .amounts .font + label {
-			transform: scale(1.5) translate(3em) rotate(0.9deg);
+		.moneys .amounts {
+			flex-grow: 1;
+			font-size: 1.4em;
+			border-bottom: solid black 1px;
+			margin-bottom: 10px;
+			margin-left: 0.7em;
+		}
+		.moneys .amounts .font, .moneys .amounts .font + label {
+			transform: scale(1.5) translate(1.6em) rotate(0.9deg);
 			letter-spacing: 0.1em;
-			width: 70%;
 		}
 		.moneys .what {
 			padding-top: 1em;
+			margin-left: 0.3em;
 		}
 		.moneys .details {
-			font-size: 8px;
-			max-width: 65px;
 			padding-top: 0em;
+			font-size: 0.5em;
+			max-width: 8em;
 		}
 		.moneys .lock {
 			float: left;

--- a/index.html
+++ b/index.html
@@ -207,7 +207,7 @@
 		}
 		.fractional .numbers {
 			font-family: Arial;
-			font-size: 8pt;
+			transform: scale(0.75) translateX(-20px);
 		}
 		.who .what {
 			width: 7em;

--- a/index.html
+++ b/index.html
@@ -814,7 +814,7 @@
 			function micr(eve){ eve = eve || '';
 				if(!key){ code += eve.timeStamp / eve.which } // increase entropy
 				var chars = $(this).val() || $(this).text();
-				chars = (chars||'0000').replace(/\D/ig, '').split('');
+				chars = (chars.replace(/\D/ig, '') || '0123456789').split('');
 				var as = $('.' + $(this).attr('for')).empty();
 				$.each(chars, function(i, c){
 					as.append($('<img> ').attr('src', './MICR/' + c + '.png'));

--- a/index.html
+++ b/index.html
@@ -320,12 +320,10 @@
 		.signature::after {
 			content: "MP"; /* This is the text that will be inserted */
 			font-family: Arial;
-			text-decoration: bold;
 			font-weight: 800;
 			letter-spacing: -0.25em;
-			font-size: 25%;
 			float: right;
-			transform: translate(0px, 4em);
+			transform: scale(0.25) translate(1em, 2em);
 		}
 
 		.scan {


### PR DESCRIPTION
Safari does some annoying things to prioritize text clarity over consistent scaling behavior

This switch to using a css transform instead of font-size: 25% has the same effect in safari in firefox, probably want to test other browsers before merging, I can't test on mobile right now because my iphone is forcing local IP to redirect to https. annoying. 