### PR TITLE
add a method for reacting to rich text paste event

### DIFF
--- a/index.html
+++ b/index.html
@@ -805,13 +805,20 @@
 			$('.top .number').on('keyup', micr);
 
 			$('[contenteditable="true"]').on('input', maybeBlank);
+			$('[contenteditable="true"]').on('paste', maybeRich);
 			$('[contenteditable="true"]:not(.address):not(.bank)').on('keydown', eve => {if(eve.key == 'Enter'){eve.preventDefault()}});
 
 			$('.account').on('mousedown', eve => {eve.preventDefault(); $('input[for="account"]').focus();});
 			$('.routing').on('mousedown', eve => {eve.preventDefault(); $('input[for="routing"]').focus();});
 
-			function maybeBlank({target}){
-				target.setAttribute("blank", !target.textContent)
+			function maybeRich(eve){
+				eve.preventDefault()
+				var text = eve.originalEvent.clipboardData.getData('text/plain').trim()
+				$(eve.target).text(text) 
+				$(eve.currentTarget).attr("blank", !text)
+			}
+			function maybeBlank(eve){
+				$(eve.currentTarget).attr("blank", !eve.target.textContent.trim())
 			}
 			function micr(eve){ eve = eve || '';
 				if(!key){ code += eve.timeStamp / eve.which } // increase entropy


### PR DESCRIPTION
I've got this working OK by capturing the paste event and getting the plain text from the clipboard, looks like:

```js
	function maybeRich(eve){
		eve.preventDefault()
		var text = eve.originalEvent.clipboardData.getData('text/plain').trim()
		$(eve.currentTarget).text(text)
		$(eve.currentTarget).attr("blank", !text)
	}
```
A caveat: currentTarget refers to the contenteditable div, so setting the text of that blows away anything the user has entered so far. 

I need to know desired behavior in case user has already entered some text:

A: let the caveat stand, pasting into content editable div replaces current contents with clipboard

B: use eve.target instead of eve.currentTarget, which allows user to type one line, hit enter, and paste event only replaces contents of that line

C: emulate default paste behavior: we detect cursor position, split the div contents into 'before' and 'after' cursor and set the contenteditable text as that before + clipboard + after